### PR TITLE
fix generations 

### DIFF
--- a/api/generate-image/index.js
+++ b/api/generate-image/index.js
@@ -1,4 +1,9 @@
 import OpenAI from 'openai';
+import dotenv from 'dotenv';
+
+// Load environment variables for Vercel dev
+dotenv.config();
+dotenv.config({ path: '.env.local', override: true });
 
 export default async function handler(req, res) {
   // Enable CORS


### PR DESCRIPTION
The Vercel dev server wasn't loading environment variables from 
.env.local for serverless API functions, causing the OPENAI_API_KEY not configured on server error.